### PR TITLE
Fixed #86: Entering IPv4 deletes other settings

### DIFF
--- a/Interface/src/components/DeviceRow.vue
+++ b/Interface/src/components/DeviceRow.vue
@@ -83,7 +83,7 @@
           type="text"
           name="MTU"
           class="MTU"
-          :value="MTU"
+          :value="internalMTU"
           :placeholder="$t('dashboard.widgets.devices.placeholder.MTU')"
           @input="(e) => updateMTU(e.target.value)"
           ref="MTU"
@@ -97,7 +97,7 @@
           type="text"
           name="additionalDNSServers"
           class="additionalDNSServers"
-          :value="additionalDNSServers"
+          :value="internalAdditionalDNSServers"
           :placeholder="
             $t('dashboard.widgets.devices.placeholder.additionalDNSServers')
           "


### PR DESCRIPTION
#86 Entering IPv4 deletes other settings
- Test cases have been passed locally.

PS: This was rather a simple issue. Another tiny issue I found is that `IPv6` field doesn't accept lowercase letters. Is that intentional or it needs a fix?