### PR TITLE
Removed repetitive parsing of JSON during backup

### DIFF
--- a/Interface/src/Widgets/Dashboard/Settings.vue
+++ b/Interface/src/Widgets/Dashboard/Settings.vue
@@ -53,9 +53,7 @@ export default {
       element.setAttribute(
         "href",
         "data:application/json;charset=utf-8," +
-          encodeURIComponent(
-            JSON.stringify(window.localStorage.getItem("vuex"))
-          )
+          encodeURIComponent(window.localStorage.getItem("vuex"))
       );
       element.setAttribute(
         "download",
@@ -90,8 +88,7 @@ export default {
       try {
         const reader = new FileReader();
         reader.onload = (e) => {
-          let backup = e.target.result.replace(/\\"/g, "\"").slice(1,-1);
-          backup = upgradeBackup(backup);
+          let backup = upgradeBackup(e.target.result);
 
           window.localStorage.setItem("vuex", backup);
           this.$store.replaceState(JSON.parse(backup));

--- a/Interface/src/Widgets/Dashboard/Settings.vue
+++ b/Interface/src/Widgets/Dashboard/Settings.vue
@@ -90,8 +90,7 @@ export default {
       try {
         const reader = new FileReader();
         reader.onload = (e) => {
-          let backup = JSON.parse(e.target.result);
-          // The backup will still be a JSON string here!
+          let backup = e.target.result.replace(/\\"/g, "\"").slice(1,-1);
           backup = upgradeBackup(backup);
 
           window.localStorage.setItem("vuex", backup);

--- a/System-Tests/package.json
+++ b/System-Tests/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "chromedriver": "85.0.0",
     "fibers": "5.0.0",
+    "glob": "^7.1.6",
     "nightwatch": "1.4.3",
     "webpack-bundle-analyzer": "3.9.0"
   },

--- a/System-Tests/package.json
+++ b/System-Tests/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "chromedriver": "85.0.0",
     "fibers": "5.0.0",
-    "glob": "^7.1.6",
+    "glob": "7.1.6",
     "nightwatch": "1.4.3",
     "webpack-bundle-analyzer": "3.9.0"
   },

--- a/System-Tests/tests/nightwatch/dashboard/dashboard_device_widget.spec.js
+++ b/System-Tests/tests/nightwatch/dashboard/dashboard_device_widget.spec.js
@@ -1,6 +1,7 @@
 const fs = require("fs").promises
 const assert = require('assert')
 const util = require('util');
+const glob = require('glob');
 const setTimeoutAsync = util.promisify(setTimeout);
 
 module.exports = {
@@ -80,6 +81,27 @@ module.exports = {
             });
         } catch (error) {
             await fs.unlink(downloadLocation)
+            throw new Error(error);
+        }
+    },
+    "Download and verify backup": async function (browser) {
+        await browser.click("#export button");
+        try {
+            await setTimeoutAsync(1000, 'waitForDownload').then(async () => {
+                let files = glob.sync("/tmp/WirtTestDownloads/dasboard-backup-*.json");
+                let file = files[files.length - 1];
+                // console.log(file);
+                try {
+                    const data = await fs.readFile(file, "utf8")
+                    let json = JSON.parse(data);
+                    assert(typeof json.version === 'number' )
+                    fs.unlink(file)
+                } catch (error) {
+                    fs.unlink(file)
+                    throw new Error(error);
+                }
+            });
+        } catch (error) {
             throw new Error(error);
         }
     },

--- a/System-Tests/tests/nightwatch/dashboard/dashboard_device_widget.spec.js
+++ b/System-Tests/tests/nightwatch/dashboard/dashboard_device_widget.spec.js
@@ -84,13 +84,12 @@ module.exports = {
             throw new Error(error);
         }
     },
-    "Download and verify backup": async function (browser) {
+    "Download and verify that backup is a simple JSON string": async function (browser) {
         await browser.click("#export button");
         try {
             await setTimeoutAsync(1000, 'waitForDownload').then(async () => {
                 let files = glob.sync("/tmp/WirtTestDownloads/dasboard-backup-*.json");
                 let file = files[files.length - 1];
-                // console.log(file);
                 try {
                     const data = await fs.readFile(file, "utf8")
                     let json = JSON.parse(data);


### PR DESCRIPTION
#95 Fixed creation of backup
Please take a look and tell if this approach seems alright. This is to convert JSON string with escape sequences to regular JSON string ready to be parsed.
`"{\"key\":\"value\"}"`  -> `{"key":"value"}`